### PR TITLE
Update description of Cloud.getFirmwareList

### DIFF
--- a/API.md
+++ b/API.md
@@ -226,7 +226,7 @@ Sends `cloud.unbind` command.
 <a name="Bulb+cloud+getFirmwareList"></a>
 
 #### cloud.getFirmwareList([sendOptions]) ⇒ <code>Promise.&lt;Object, ResponseError&gt;</code>
-Remove device from TP-Link cloud.
+Get device's TP-Link cloud firmware list.
 
 Sends `cloud.get_intl_fw_list` command.
 
@@ -2138,7 +2138,7 @@ Sends `cloud.unbind` command.
 <a name="Plug+cloud+getFirmwareList"></a>
 
 #### cloud.getFirmwareList([sendOptions]) ⇒ <code>Promise.&lt;Object, ResponseError&gt;</code>
-Remove device from TP-Link cloud.
+Get device's TP-Link cloud firmware list.
 
 Sends `cloud.get_intl_fw_list` command.
 
@@ -3158,7 +3158,7 @@ Sends `cloud.unbind` command.
 <a name="Cloud+getFirmwareList"></a>
 
 ### cloud.getFirmwareList([sendOptions]) ⇒ <code>Promise.&lt;Object, ResponseError&gt;</code>
-Remove device from TP-Link cloud.
+Get device's TP-Link cloud firmware list.
 
 Sends `cloud.get_intl_fw_list` command.
 

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ Sends `cloud.unbind` command.
 <a name="Bulb+cloud+getFirmwareList"></a>
 
 #### cloud.getFirmwareList([sendOptions]) ⇒ <code>Promise.&lt;Object, ResponseError&gt;</code>
-Remove device from TP-Link cloud.
+Get device's TP-Link cloud firmware list.
 
 Sends `cloud.get_intl_fw_list` command.
 
@@ -1578,7 +1578,7 @@ Sends `cloud.unbind` command.
 <a name="Plug+cloud+getFirmwareList"></a>
 
 #### cloud.getFirmwareList([sendOptions]) ⇒ <code>Promise.&lt;Object, ResponseError&gt;</code>
-Remove device from TP-Link cloud.
+Get device's TP-Link cloud firmware list.
 
 Sends `cloud.get_intl_fw_list` command.
 

--- a/src/shared/cloud.js
+++ b/src/shared/cloud.js
@@ -48,7 +48,7 @@ class Cloud {
     }, sendOptions);
   }
   /**
-   * Remove device from TP-Link cloud.
+   * Get device's TP-Link cloud firmware list.
    *
    * Sends `cloud.get_intl_fw_list` command.
    * @param  {SendOptions} [sendOptions]


### PR DESCRIPTION
The description of `Cloud.getFirmwareList` is the same as `Cloud.unbind`.
I updated it to say "Get device's TP-Link cloud firmware list."