### PR TITLE
Simple approach to fixing exceptions on polling devices without energy meters

### DIFF
--- a/src/plug/index.js
+++ b/src/plug/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
 const Device = require('../device');
 const Away = require('./away');
 const Cloud = require('../shared/cloud');
@@ -32,7 +34,7 @@ class Plug extends Device {
    * @param  {Object}  options
    * @param  {Number} [options.inUseThreshold=0]
    */
-  constructor (options) {
+  constructor(options) {
     super(options);
 
     this.log.debug('plug.constructor()');
@@ -111,15 +113,15 @@ class Plug extends Device {
    * Returns cached results from last retrieval of `system.sys_info`.
    * @return {Object} system.sys_info
    */
-  get sysInfo () {
+  get sysInfo() {
     return super.sysInfo;
   }
   /**
    * @private
    */
-  set sysInfo (sysInfo) {
+  set sysInfo(sysInfo) {
     super.sysInfo = sysInfo;
-    this.supportsEmeter = (sysInfo.feature && typeof sysInfo.feature === 'string' ? sysInfo.feature.indexOf('ENE') >= 0 : false);
+    this.supportsEmeter = sysInfo.feature && typeof sysInfo.feature === 'string' ? sysInfo.feature.indexOf('ENE') >= 0 : false;
     this.log.debug('[%s] plug sysInfo set', this.alias);
     this.emitEvents();
   }
@@ -148,9 +150,9 @@ class Plug extends Device {
    * Otherwise fallback on relay state:  `relay_state === 1`
    * @return {boolean}
    */
-  get inUse () {
+  get inUse() {
     if (this.supportsEmeter) {
-      return (this.emeter.realtime.power > this.inUseThreshold);
+      return this.emeter.realtime.power > this.inUseThreshold;
     }
     return this.relayState;
   }
@@ -158,8 +160,8 @@ class Plug extends Device {
    * `sys_info.relay_state === 1`
    * @return {boolean}
    */
-  get relayState () {
-    return (this.sysInfo.relay_state === 1);
+  get relayState() {
+    return this.sysInfo.relay_state === 1;
   }
   /**
    * Requests common Plug status details in a single request.
@@ -170,20 +172,28 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, Error>} parsed JSON response
    */
-  async getInfo (sendOptions) {
-    // TODO force TCP unless overriden here
-    // TODO switch to sendCommand, but need to handle error for devices that don't support emeter
-    let data = await this.send('{"emeter":{"get_realtime":{}},"schedule":{"get_next_action":{}},"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}}}', sendOptions);
-    this.sysInfo = data.system.get_sysinfo;
-    this.cloud.info = data.cnCloud.get_info;
-    this.emeter.realtime = data.emeter.get_realtime;
-    this.schedule.nextAction = data.schedule.get_next_action;
-    return {
-      sysInfo: this.sysInfo,
-      cloud: {info: this.cloud.info},
-      emeter: {realtime: this.emeter.realtime},
-      schedule: {nextAction: this.schedule.nextAction}
-    };
+  getInfo(sendOptions) {
+    var _this = this;
+
+    return _asyncToGenerator(function* () {
+      // TODO force TCP unless overriden here
+      // TODO switch to sendCommand, but need to handle error for devices that don't support emeter
+      let data = yield _this.send('{"emeter":{"get_realtime":{}},"schedule":{"get_next_action":{}},"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}}}', sendOptions);
+      _this.sysInfo = data.system.get_sysinfo;
+      _this.cloud.info = data.cnCloud.get_info;
+      if (data.emeter.hasOwnProperty('err_code')) {
+        _this.emeter.realtime = null;
+      } else {
+        _this.emeter.realtime = data.emeter.get_realtime;
+      }
+      _this.schedule.nextAction = data.schedule.get_next_action;
+      return {
+        sysInfo: _this.sysInfo,
+        cloud: { info: _this.cloud.info },
+        emeter: { realtime: _this.emeter.realtime },
+        schedule: { nextAction: _this.schedule.nextAction }
+      };
+    })();
   }
 
   /**
@@ -191,13 +201,17 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async getInUse (sendOptions) {
-    if (this.supportsEmeter) {
-      await this.emeter.getRealtime(sendOptions);
-    } else {
-      await this.getSysInfo(sendOptions);
-    }
-    return this.inUse;
+  getInUse(sendOptions) {
+    var _this2 = this;
+
+    return _asyncToGenerator(function* () {
+      if (_this2.supportsEmeter) {
+        yield _this2.emeter.getRealtime(sendOptions);
+      } else {
+        yield _this2.getSysInfo(sendOptions);
+      }
+      return _this2.inUse;
+    })();
   }
   /**
    * Get Plug LED state (night mode).
@@ -206,9 +220,13 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>} LED State, true === on
    */
-  async getLedState (sendOptions) {
-    let sysInfo = await this.getSysInfo(sendOptions);
-    return (sysInfo.led_off === 0);
+  getLedState(sendOptions) {
+    var _this3 = this;
+
+    return _asyncToGenerator(function* () {
+      let sysInfo = yield _this3.getSysInfo(sendOptions);
+      return sysInfo.led_off === 0;
+    })();
   }
   /**
    * Turn Plug LED on/off (night mode).
@@ -218,10 +236,14 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async setLedState (value, sendOptions) {
-    await this.sendCommand(`{"system":{"set_led_off":{"off":${(value ? 0 : 1)}}}}`, sendOptions);
-    this.sysInfo.set_led_off = (value ? 0 : 1);
-    return true;
+  setLedState(value, sendOptions) {
+    var _this4 = this;
+
+    return _asyncToGenerator(function* () {
+      yield _this4.sendCommand(`{"system":{"set_led_off":{"off":${value ? 0 : 1}}}}`, sendOptions);
+      _this4.sysInfo.set_led_off = value ? 0 : 1;
+      return true;
+    })();
   }
   /**
    * Get Plug relay state (on/off).
@@ -230,9 +252,13 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async getPowerState (sendOptions) {
-    let sysInfo = await this.getSysInfo(sendOptions);
-    return (sysInfo.relay_state === 1);
+  getPowerState(sendOptions) {
+    var _this5 = this;
+
+    return _asyncToGenerator(function* () {
+      let sysInfo = yield _this5.getSysInfo(sendOptions);
+      return sysInfo.relay_state === 1;
+    })();
   }
   /**
    * Turns Plug relay on/off.
@@ -242,11 +268,15 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async setPowerState (value, sendOptions) {
-    await this.sendCommand(`{"system":{"set_relay_state":{"state":${(value ? 1 : 0)}}}}`, sendOptions);
-    this.sysInfo.relay_state = (value ? 1 : 0);
-    this.emitEvents();
-    return true;
+  setPowerState(value, sendOptions) {
+    var _this6 = this;
+
+    return _asyncToGenerator(function* () {
+      yield _this6.sendCommand(`{"system":{"set_relay_state":{"state":${value ? 1 : 0}}}}`, sendOptions);
+      _this6.sysInfo.relay_state = value ? 1 : 0;
+      _this6.emitEvents();
+      return true;
+    })();
   }
   /**
    * Toggles Plug relay state.
@@ -255,10 +285,14 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async togglePowerState (sendOptions) {
-    const powerState = await this.getPowerState(sendOptions);
-    await this.setPowerState(!powerState, sendOptions);
-    return !powerState;
+  togglePowerState(sendOptions) {
+    var _this7 = this;
+
+    return _asyncToGenerator(function* () {
+      const powerState = yield _this7.getPowerState(sendOptions);
+      yield _this7.setPowerState(!powerState, sendOptions);
+      return !powerState;
+    })();
   }
   /**
    * Blink Plug LED.
@@ -272,26 +306,34 @@ class Plug extends Device {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<boolean, ResponseError>}
    */
-  async blink (times = 5, rate = 1000, sendOptions) {
-    let delay = (t) => { return new Promise((resolve) => { setTimeout(resolve, t); }); };
+  blink(times = 5, rate = 1000, sendOptions) {
+    var _this8 = this;
 
-    let origLedState = await this.getLedState(sendOptions);
-    let lastBlink = Date.now();
+    return _asyncToGenerator(function* () {
+      let delay = function delay(t) {
+        return new Promise(function (resolve) {
+          setTimeout(resolve, t);
+        });
+      };
 
-    let currLedState = false;
-    for (var i = 0; i < times * 2; i++) {
-      currLedState = !currLedState;
-      lastBlink = Date.now();
-      await this.setLedState(currLedState, sendOptions);
-      let timeToWait = (rate / 2) - (Date.now() - lastBlink);
-      if (timeToWait > 0) {
-        await delay(timeToWait);
+      let origLedState = yield _this8.getLedState(sendOptions);
+      let lastBlink = Date.now();
+
+      let currLedState = false;
+      for (var i = 0; i < times * 2; i++) {
+        currLedState = !currLedState;
+        lastBlink = Date.now();
+        yield _this8.setLedState(currLedState, sendOptions);
+        let timeToWait = rate / 2 - (Date.now() - lastBlink);
+        if (timeToWait > 0) {
+          yield delay(timeToWait);
+        }
       }
-    }
-    if (currLedState !== origLedState) {
-      await this.setLedState(origLedState, sendOptions);
-    }
-    return true;
+      if (currLedState !== origLedState) {
+        yield _this8.setLedState(origLedState, sendOptions);
+      }
+      return true;
+    })();
   }
   /**
    * Plug's relay was turned on.
@@ -327,8 +369,10 @@ class Plug extends Device {
   /**
    * @private
    */
-  emitEvents () {
-    if (!this.emitEventsEnabled) { return; }
+  emitEvents() {
+    if (!this.emitEventsEnabled) {
+      return;
+    }
 
     const inUse = this.inUse;
     const relayState = this.relayState;

--- a/src/plug/index.js
+++ b/src/plug/index.js
@@ -176,9 +176,7 @@ class Plug extends Device {
     let data = await this.send('{"emeter":{"get_realtime":{}},"schedule":{"get_next_action":{}},"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}}}', sendOptions);
     this.sysInfo = data.system.get_sysinfo;
     this.cloud.info = data.cnCloud.get_info;
-    if (data.emeter.hasOwnProperty('err_code')) {
-      this.emeter.realtime = null;
-    } else {
+    if (data.emeter.hasOwnProperty('get_realtime')) {
       this.emeter.realtime = data.emeter.get_realtime;
     }
     this.schedule.nextAction = data.schedule.get_next_action;

--- a/src/plug/index.js
+++ b/src/plug/index.js
@@ -176,7 +176,11 @@ class Plug extends Device {
     let data = await this.send('{"emeter":{"get_realtime":{}},"schedule":{"get_next_action":{}},"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}}}', sendOptions);
     this.sysInfo = data.system.get_sysinfo;
     this.cloud.info = data.cnCloud.get_info;
-    this.emeter.realtime = data.emeter.get_realtime;
+    if (data.emeter.hasOwnProperty('err_code')) {
+      this.emeter.realtime = null;
+    } else {
+      this.emeter.realtime = data.emeter.get_realtime;
+    }
     this.schedule.nextAction = data.schedule.get_next_action;
     return {
       sysInfo: this.sysInfo,

--- a/src/shared/emeter.js
+++ b/src/shared/emeter.js
@@ -3,8 +3,11 @@
 /**
  * Eemter
  */
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
 class Emeter {
-  constructor (device, apiModuleName) {
+  constructor(device, apiModuleName) {
     this.device = device;
     this.apiModuleName = apiModuleName;
 
@@ -14,14 +17,17 @@ class Emeter {
    * Returns cached results from last retrieval of `emeter.get_realtime`.
    * @return {Object}
    */
-  get realtime () {
+  get realtime() {
     return this._realtime;
   }
   /**
    * @private
    */
-  set realtime (realtime) {
-    let normalize = function (propName, propName2, multiplier) {
+  set realtime(realtime) {
+    let normalize = function normalize(propName, propName2, multiplier) {
+      if (null == realtime) {
+        return null;
+      }
       if (realtime[propName] != null && realtime[propName2] == null) {
         realtime[propName2] = Math.floor(realtime[propName] * multiplier);
       } else if (realtime[propName] == null && realtime[propName2] != null) {
@@ -45,11 +51,15 @@ class Emeter {
    * @param  {SendOptions}  [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  async getRealtime (sendOptions) {
-    this.realtime = await this.device.sendCommand({
-      [this.apiModuleName]: {get_realtime: {}}
-    }, sendOptions);
-    return this.realtime;
+  getRealtime(sendOptions) {
+    var _this = this;
+
+    return _asyncToGenerator(function* () {
+      _this.realtime = yield _this.device.sendCommand({
+        [_this.apiModuleName]: { get_realtime: {} }
+      }, sendOptions);
+      return _this.realtime;
+    })();
   }
   /**
    * Get Daily Emeter Statisics.
@@ -60,10 +70,14 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  async getDayStats (year, month, sendOptions) {
-    return this.device.sendCommand({
-      [this.apiModuleName]: { get_daystat: { year, month } }
-    }, sendOptions);
+  getDayStats(year, month, sendOptions) {
+    var _this2 = this;
+
+    return _asyncToGenerator(function* () {
+      return _this2.device.sendCommand({
+        [_this2.apiModuleName]: { get_daystat: { year, month } }
+      }, sendOptions);
+    })();
   }
   /**
    * Get Monthly Emeter Statisics.
@@ -73,10 +87,14 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  async getMonthStats (year, sendOptions) {
-    return this.device.sendCommand({
-      [this.apiModuleName]: { get_monthstat: { year } }
-    }, sendOptions);
+  getMonthStats(year, sendOptions) {
+    var _this3 = this;
+
+    return _asyncToGenerator(function* () {
+      return _this3.device.sendCommand({
+        [_this3.apiModuleName]: { get_monthstat: { year } }
+      }, sendOptions);
+    })();
   }
   /**
    * Erase Emeter Statistics.
@@ -85,10 +103,14 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  async eraseStats (sendOptions) {
-    return this.device.sendCommand({
-      [this.apiModuleName]: { erase_emeter_stat: {} }
-    }, sendOptions);
+  eraseStats(sendOptions) {
+    var _this4 = this;
+
+    return _asyncToGenerator(function* () {
+      return _this4.device.sendCommand({
+        [_this4.apiModuleName]: { erase_emeter_stat: {} }
+      }, sendOptions);
+    })();
   }
 }
 

--- a/src/shared/emeter.js
+++ b/src/shared/emeter.js
@@ -22,6 +22,9 @@ class Emeter {
    */
   set realtime (realtime) {
     let normalize = function (propName, propName2, multiplier) {
+      if (null == realtime) {
+        return null;
+      }
       if (realtime[propName] != null && realtime[propName2] == null) {
         realtime[propName2] = Math.floor(realtime[propName] * multiplier);
       } else if (realtime[propName] == null && realtime[propName2] != null) {

--- a/src/shared/emeter.js
+++ b/src/shared/emeter.js
@@ -22,9 +22,6 @@ class Emeter {
    */
   set realtime (realtime) {
     let normalize = function (propName, propName2, multiplier) {
-      if (null == realtime) {
-        return null;
-      }
       if (realtime[propName] != null && realtime[propName2] == null) {
         realtime[propName2] = Math.floor(realtime[propName] * multiplier);
       } else if (realtime[propName] == null && realtime[propName2] != null) {
@@ -32,10 +29,12 @@ class Emeter {
       }
     };
 
-    normalize('current', 'current_ma', 1000);
-    normalize('power', 'power_mw', 1000);
-    normalize('total', 'total_wh', 1000);
-    normalize('voltage', 'voltage_mv', 1000);
+    if (realtime != null) {
+      normalize('current', 'current_ma', 1000);
+      normalize('power', 'power_mw', 1000);
+      normalize('total', 'total_wh', 1000);
+      normalize('voltage', 'voltage_mv', 1000);
+    }
 
     this._realtime = realtime;
     this.device.emit('emeter-realtime-update', this._realtime);

--- a/src/shared/emeter.js
+++ b/src/shared/emeter.js
@@ -3,11 +3,8 @@
 /**
  * Eemter
  */
-
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 class Emeter {
-  constructor(device, apiModuleName) {
+  constructor (device, apiModuleName) {
     this.device = device;
     this.apiModuleName = apiModuleName;
 
@@ -17,17 +14,14 @@ class Emeter {
    * Returns cached results from last retrieval of `emeter.get_realtime`.
    * @return {Object}
    */
-  get realtime() {
+  get realtime () {
     return this._realtime;
   }
   /**
    * @private
    */
-  set realtime(realtime) {
-    let normalize = function normalize(propName, propName2, multiplier) {
-      if (null == realtime) {
-        return null;
-      }
+  set realtime (realtime) {
+    let normalize = function (propName, propName2, multiplier) {
       if (realtime[propName] != null && realtime[propName2] == null) {
         realtime[propName2] = Math.floor(realtime[propName] * multiplier);
       } else if (realtime[propName] == null && realtime[propName2] != null) {
@@ -51,15 +45,11 @@ class Emeter {
    * @param  {SendOptions}  [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  getRealtime(sendOptions) {
-    var _this = this;
-
-    return _asyncToGenerator(function* () {
-      _this.realtime = yield _this.device.sendCommand({
-        [_this.apiModuleName]: { get_realtime: {} }
-      }, sendOptions);
-      return _this.realtime;
-    })();
+  async getRealtime (sendOptions) {
+    this.realtime = await this.device.sendCommand({
+      [this.apiModuleName]: {get_realtime: {}}
+    }, sendOptions);
+    return this.realtime;
   }
   /**
    * Get Daily Emeter Statisics.
@@ -70,14 +60,10 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  getDayStats(year, month, sendOptions) {
-    var _this2 = this;
-
-    return _asyncToGenerator(function* () {
-      return _this2.device.sendCommand({
-        [_this2.apiModuleName]: { get_daystat: { year, month } }
-      }, sendOptions);
-    })();
+  async getDayStats (year, month, sendOptions) {
+    return this.device.sendCommand({
+      [this.apiModuleName]: { get_daystat: { year, month } }
+    }, sendOptions);
   }
   /**
    * Get Monthly Emeter Statisics.
@@ -87,14 +73,10 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  getMonthStats(year, sendOptions) {
-    var _this3 = this;
-
-    return _asyncToGenerator(function* () {
-      return _this3.device.sendCommand({
-        [_this3.apiModuleName]: { get_monthstat: { year } }
-      }, sendOptions);
-    })();
+  async getMonthStats (year, sendOptions) {
+    return this.device.sendCommand({
+      [this.apiModuleName]: { get_monthstat: { year } }
+    }, sendOptions);
   }
   /**
    * Erase Emeter Statistics.
@@ -103,14 +85,10 @@ class Emeter {
    * @param  {SendOptions} [sendOptions]
    * @return {Promise<Object, ResponseError>} parsed JSON response
    */
-  eraseStats(sendOptions) {
-    var _this4 = this;
-
-    return _asyncToGenerator(function* () {
-      return _this4.device.sendCommand({
-        [_this4.apiModuleName]: { erase_emeter_stat: {} }
-      }, sendOptions);
-    })();
+  async eraseStats (sendOptions) {
+    return this.device.sendCommand({
+      [this.apiModuleName]: { erase_emeter_stat: {} }
+    }, sendOptions);
   }
 }
 


### PR DESCRIPTION
I made a few small changes to test for the return value indicating that a device doesn't have an energy meter and then to handle that case later. Hope these are consistent with how you want to maintain the library. Thanks so much for enabling others to control these devices so simply!