### PR TITLE
Adds HS103 to the compatible list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ TP-Link Smart Home API
 
 ## Supported Devices
 
-| Model                                           | Type |
-|-------------------------------------------------|------|
-| HS100, HS105, HS107, HS110, HS200, HS220, HS300 | Plug |
-| LB100, LB110, LB120, LB130, LB200, LB230        | Bulb |
+| Model                                                  | Type |
+|--------------------------------------------------------|------|
+| HS100, HS103, HS105, HS107, HS110, HS200, HS220, HS300 | Plug |
+| LB100, LB110, LB120, LB130, LB200, LB230               | Bulb |
 
 ## Related Projects
 


### PR DESCRIPTION
I just validated that the HS103 works via the below command:

```
tplink-smarthome-api send <HOST>  '{"system":{"set_relay_state":{"state":1}}}'
```

Note: I joined it to my network via the Kasa app before playing around with automation libraries like this great one.