### PR TITLE
fixed unhandled network error

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -379,21 +379,15 @@ class Device extends EventEmitter {
    * @return {Device|Bulb|Plug}          this
    */
   startPolling(interval) {
-    const fn = async () => {
-      try {
-        await this.getInfo();
-      } catch (err) {
-        this.log.debug(
-          '[%s] device.startPolling(): getInfo(): error:',
-          this.alias,
-          err
-        );
+    const fn = () => {
+      this.getInfo().catch((err) => {
+        this.log.debug('[%s] device.startPolling(): getInfo(): error:', this.alias, err);
         /**
          * @event Device#polling-error
          * @property {Error} error
          */
         this.emit('polling-error', err);
-      }
+      })
     };
     this.pollingTimer = setInterval(fn, interval);
     fn();


### PR DESCRIPTION
This should fix #71 as discussed in the issue.
Otherwise rejections on network errors are not handled which will a warning with newer node versions and might crash the process in future node versions (you can configure it to do so today already).