### PR TITLE
Add feature to fire brightness change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Change Log
 
+## Unrelased
+
+### Added :heavy_plus_sign:
+
+- `Plug`
+  - For plugs with dimmer support, Emit `brightness-change` and `brightness-update`.
+
 ## 3.0.0-beta.0 / 2020-08-26
 
 ### Breaking Changes :boom:

--- a/docs/classes/plug.html
+++ b/docs/classes/plug.html
@@ -93,6 +93,9 @@
 						<dd><p>Plug#power-update</p>
 						</dd>
 						<dt>fires</dt>
+						<dd><p>Plug#brightness-change</p>
+            </dd>
+						<dt>fires</dt>
 						<dd><p>Plug#in-use</p>
 						</dd>
 						<dt>fires</dt>

--- a/docs/classes/plug.html
+++ b/docs/classes/plug.html
@@ -93,9 +93,6 @@
 						<dd><p>Plug#power-update</p>
 						</dd>
 						<dt>fires</dt>
-						<dd><p>Plug#brightness-change</p>
-            </dd>
-						<dt>fires</dt>
 						<dd><p>Plug#in-use</p>
 						</dd>
 						<dt>fires</dt>

--- a/src/plug/index.ts
+++ b/src/plug/index.ts
@@ -113,7 +113,7 @@ export default class Plug extends Device {
 
   emitEventsEnabled = true;
 
-  lastState = { inUse: false, relayState: false };
+  lastState = { inUse: false, relayState: false, brightness: undefined };
 
   static readonly apiModules = {
     system: 'system',
@@ -240,6 +240,7 @@ export default class Plug extends Device {
     if (this.sysInfo) {
       this.lastState.inUse = this.inUse;
       this.lastState.relayState = this.relayState;
+      if (this.supportsDimmer) this.lastState.brightness = this.brightness;
     }
   }
 
@@ -401,6 +402,14 @@ export default class Plug extends Device {
    */
   get supportsDimmer(): boolean {
     return 'brightness' in this.sysInfo;
+  }
+
+  /**
+   * Cached value of `sysinfo.brightness`.
+   * @returns value between 0 and 100, inclusive, only if `supportsDimmer` is true.
+   */
+  get brightness() {
+    return this.supportsDimmer ? this.sysInfo.brightness : undefined;
   }
 
   /**
@@ -673,6 +682,7 @@ export default class Plug extends Device {
 
     const { inUse } = this;
     const { relayState } = this;
+    const { brightness } = this;
 
     this.log.debug(
       '[%s] plug.emitEvents() inUse: %s relayState: %s lastState: %j',
@@ -700,5 +710,10 @@ export default class Plug extends Device {
       }
     }
     this.emit('power-update', relayState);
+
+    if (this.supportsDimmer && this.lastState.brightness !== brightness) {
+      this.lastState.brightness = brightness;
+      this.emit('brightness-change', brightness);
+    }
   }
 }

--- a/src/plug/index.ts
+++ b/src/plug/index.ts
@@ -113,7 +113,11 @@ export default class Plug extends Device {
 
   emitEventsEnabled = true;
 
-  lastState = { inUse: false, relayState: false, brightness: undefined };
+  lastState: { inUse: boolean; relayState: boolean; brightness?: number } = {
+    inUse: false,
+    relayState: false,
+    brightness: undefined,
+  };
 
   static readonly apiModules = {
     system: 'system',
@@ -680,9 +684,7 @@ export default class Plug extends Device {
       return;
     }
 
-    const { inUse } = this;
-    const { relayState } = this;
-    const { brightness } = this;
+    const { inUse, relayState, brightness } = this;
 
     this.log.debug(
       '[%s] plug.emitEvents() inUse: %s relayState: %s lastState: %j',

--- a/src/plug/index.ts
+++ b/src/plug/index.ts
@@ -113,10 +113,9 @@ export default class Plug extends Device {
 
   emitEventsEnabled = true;
 
-  lastState: { inUse: boolean; relayState: boolean; brightness?: number } = {
+  lastState: { inUse: boolean; relayState: boolean } = {
     inUse: false,
     relayState: false,
-    brightness: undefined,
   };
 
   static readonly apiModules = {
@@ -244,7 +243,6 @@ export default class Plug extends Device {
     if (this.sysInfo) {
       this.lastState.inUse = this.inUse;
       this.lastState.relayState = this.relayState;
-      if (this.supportsDimmer) this.lastState.brightness = this.brightness;
     }
   }
 
@@ -684,7 +682,7 @@ export default class Plug extends Device {
       return;
     }
 
-    const { inUse, relayState, brightness } = this;
+    const { inUse, relayState } = this;
 
     this.log.debug(
       '[%s] plug.emitEvents() inUse: %s relayState: %s lastState: %j',
@@ -712,10 +710,5 @@ export default class Plug extends Device {
       }
     }
     this.emit('power-update', relayState);
-
-    if (this.supportsDimmer && this.lastState.brightness !== brightness) {
-      this.lastState.brightness = brightness;
-      this.emit('brightness-change', brightness);
-    }
   }
 }

--- a/test/plug/dimmer.js
+++ b/test/plug/dimmer.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-await-in-loop */
+const sinon = require('sinon');
 const { expect } = require('../setup');
 
 module.exports = function () {
@@ -18,6 +19,43 @@ module.exports = function () {
         si = await this.device.getSysInfo();
         expect(si.brightness).to.eql(20);
       });
+
+      it('should emit brightness-change when brightness changes to a different value', async function () {
+        if (!this.device.supportsDimmer) return;
+        const spy = sinon.spy();
+
+        const dimmer = this.device.dimmer;
+        await dimmer.setBrightness(50);
+
+        this.device.on('brightness-change', spy);
+
+        await dimmer.setBrightness(60);
+        await dimmer.setBrightness(70);
+        await dimmer.setBrightness(70);
+
+        expect(spy, 'brightness-change').to.be.calledTwice;
+        expect(spy.firstCall, 'brightness-change').to.be.calledWithExactly(60);
+        expect(spy.secondCall, 'brightness-change').to.be.calledWithExactly(70);
+      });
+
+      it('should emit brightness-update for each brightness update', async function () {
+        if (!this.device.supportsDimmer) return;
+        const spy = sinon.spy();
+
+        const dimmer = this.device.dimmer;
+        await dimmer.setBrightness(50);
+
+        this.device.on('brightness-update', spy);
+
+        await dimmer.setBrightness(60);
+        await dimmer.setBrightness(70);
+        await dimmer.setBrightness(70);
+
+        expect(spy, 'brightness-update').to.be.calledThrice;
+        expect(spy.firstCall, 'brightness-update').to.be.calledWithExactly(60);
+        expect(spy.secondCall, 'brightness-update').to.be.calledWithExactly(70);
+        expect(spy.thirdCall, 'brightness-update').to.be.calledWithExactly(70);
+      });
     });
 
     describe('#setDimmerTransition()', function () {
@@ -36,6 +74,43 @@ module.exports = function () {
         ).to.eventually.have.property('err_code', 0);
         si = await this.device.getSysInfo();
         expect(si.brightness).to.eql(20);
+      });
+
+      it('should emit brightness-change when brightness changes to a different value', async function () {
+        if (!this.device.supportsDimmer) return;
+        const spy = sinon.spy();
+
+        const dimmer = this.device.dimmer;
+        await dimmer.setDimmerTransition({ brightness: 50 });
+
+        this.device.on('brightness-change', spy);
+
+        await dimmer.setDimmerTransition({ brightness: 60 });
+        await dimmer.setDimmerTransition({ brightness: 70 });
+        await dimmer.setDimmerTransition({ brightness: 70 });
+
+        expect(spy, 'brightness-change').to.be.calledTwice;
+        expect(spy.firstCall, 'brightness-change').to.be.calledWithExactly(60);
+        expect(spy.secondCall, 'brightness-change').to.be.calledWithExactly(70);
+      });
+
+      it('should emit brightness-update for each brightness update', async function () {
+        if (!this.device.supportsDimmer) return;
+        const spy = sinon.spy();
+
+        const dimmer = this.device.dimmer;
+        await dimmer.setDimmerTransition({ brightness: 50 });
+
+        this.device.on('brightness-update', spy);
+
+        await dimmer.setDimmerTransition({ brightness: 60 });
+        await dimmer.setDimmerTransition({ brightness: 70 });
+        await dimmer.setDimmerTransition({ brightness: 70 });
+
+        expect(spy, 'brightness-update').to.be.calledThrice;
+        expect(spy.firstCall, 'brightness-update').to.be.calledWithExactly(60);
+        expect(spy.secondCall, 'brightness-update').to.be.calledWithExactly(70);
+        expect(spy.thirdCall, 'brightness-update').to.be.calledWithExactly(70);
       });
     });
 


### PR DESCRIPTION
There is currently no way to trigger off of brightness changes for plugs/switches that support dimming. This feature adds a `brightness-change` event that fires when the brightness changes after polling. It is only supported when `.supportsDimmer` is `true`.

Apologizes if any of the typing isn't right - I'm still new to TS.