### PR TITLE
Fixed a small bug in multi-plug example, and separated out device ip …

### DIFF
--- a/examples/multi-plug.js
+++ b/examples/multi-plug.js
@@ -1,3 +1,5 @@
+const ipAddress = '192.168.0.100';
+
 const util = require('util');
 
 const { Client } = require('..'); // or require('tplink-smarthome-api')
@@ -45,7 +47,7 @@ const monitorEvents = function monitorEvents(device) {
 };
 
 (async () => {
-  const device = await client.getDevice({ host: '10.0.1.136' });
+  const device = await client.getDevice({ host: ipAddress });
 
   console.log(device.alias);
 
@@ -60,7 +62,7 @@ const monitorEvents = function monitorEvents(device) {
 
   await Promise.all(
     Array.from(device.children.keys(), async (childId) => {
-      const childPlug = await client.getDevice({ host: '10.0.1.136', childId });
+      const childPlug = await client.getDevice({ host: ipAddress, childId: childId });
       monitorEvents(childPlug);
     })
   );


### PR DESCRIPTION
The multi-plug example worked, but the line that got the childPlug had a bug in that it didn't specify the childId properly. The example functioned, but if the code was used to write a real-world program then the bug surfaced. For example, I used this code to turn a multi-switch on/off. As written all 3 ports of the switch would toggle. This pull request fixes that in the example.

I also refactored out the IP address of the device just to make the example more clear.