### PR TITLE
Fix #124 "TypeError: Found non-callable @@iterator" error and various…

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,7 +139,10 @@ async function sendCommandDynamic(
     // collection of all call signatures and failing.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const func = device[command] as (...args: any) => Promise<any>;
-    const results = await func.apply(device, [...commandParams, { ...sendOptions }]);
+    const results = await func.apply(device, [
+      ...commandParams,
+      { ...sendOptions },
+    ]);
 
     console.log('response:');
     console.dir(results, { colors: program.opts().color === 'on', depth: 10 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -371,7 +371,7 @@ for (const command of commandSetup) {
     : '';
 
   const cmd = program
-    .command(`${command.name} <host> ${paramsString}`)
+    .command(`${command.name} <host>${paramsString ? ` ${paramsString}` : ''}`)
     .description(
       `Send ${command.name} to device (using Device#${command.name})`
     )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -349,7 +349,7 @@ const commandSetup: CommandSetup[] = [
   { name: 'getModel', supportsChildId: true },
   {
     name: 'setPowerState',
-    params: [{ name: 'state', type: 'boolean', optional: true }],
+    params: [{ name: 'state', type: 'boolean' }],
     supportsChildId: true,
   },
   {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,7 +115,7 @@ async function sendCommandDynamic(
   // eslint-disable-next-line @typescript-eslint/ban-types
   command: Exclude<keyof PickProperties<AnyDevice, Function>, undefined>,
   commandParams: Array<boolean | number | string> = [],
-  sendOptions: SendOptions,
+  sendOptions?: SendOptions,
   childId?: string
 ): Promise<void> {
   try {
@@ -131,12 +131,6 @@ async function sendCommandDynamic(
     );
     const device = await client.getDevice({ host, port, childId });
 
-    // This line gets "TypeError: Found non-callable @@iterator" error
-    // // @ts-ignore: ignoring for now
-    // const results = await device[command](...commandParams);
-
-    // Use (...args:any) typecast to pass the call-by-name that otherwise picks up
-    // collection of all call signatures and failing.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const func = device[command] as (...args: any) => Promise<any>;
     const results = await func.apply(device, [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -380,22 +380,21 @@ for (const command of commandSetup) {
     cmd.option('-c, --childId [childId]', 'childId');
   }
 
-  // From commander README:
-  // The action handler gets passed a parameter for each command-argument you
-  // declared, and two additional parameters which are the parsed options and
-  // the command object itself.
-  cmd.action((...paramsInput) => {
-    // To deal with arbitrary counbt of command-arguments, we take all into
-    // variadic paramsInput to sort out last two into optionsInput and
-    // (UNUSED) thisCommand:
-    const [optionsInput /* UNUSED: , thisCommand */] = paramsInput.splice(
-      paramsInput.length - 2
-    );
-    const host = paramsInput.shift();
+  cmd.action((...args) => {
+    // commander provides last parameter as reference to current command
+    // remove it with slice
+    const [host, arg2, arg3] = args.slice(0, -1);
     const [hostOnly, port] = host.split(':');
 
-    const commandParams = setParamTypes(paramsInput, command);
-    const { childId, ...sendOptions } = optionsInput;
+    // signatures will be either:
+    //   host, options (arg2), params (arg3)
+    //   host, params (arg2)
+    const options = arg3 === undefined ? arg2 : arg3;
+    const params = arg3 === undefined ? undefined : arg2;
+
+    const commandParams = setParamTypes(params, command);
+
+    const { childId, ...sendOptions } = options;
     sendCommandDynamic(
       hostOnly,
       port,


### PR DESCRIPTION
… other cli issues

1. Add explicit sendOptions arg to sendCommandDynamic() (also correctly log transport if set in sendOptions)
2. Fix commander action arguments for commands in CommandSetup array
3. Above changes fix #124 "TypeError: Found non-callable @@iterator" error for all commands in CommandSetup array
4. Allow explicit optional params in CommandSetup type and use it in commander setup
5. Fix setAlias command to have string parameter
6. Define setPowerState parameter as optional

Background:

Call logic of API methods in sendCommandDynamic() may have worked at some point (when there were fewer methods), but got broken when more methods were added to the API.
When Object[variable] pattern is used to select which method to call by name, TypeScript composes a compound type for all signatures of all methods, and refuses to call the selected method since the provided arguments don't match the compound signature, even if they match the specific method. Solution implemented to wipe out call arguments signature and use func.apply().

Further, sendCommandDynamic() was not receiving correct arguments due to the problem how the command.action() callback arguments were done. This logic needed complete revamp.

Few minor issues were noticed and fixed as well - always optional parameters in CommandSetup array, missing setAlias parameter.