### PR TITLE
feat(Client): add devicesUseDiscoveryPort to DiscoveryOptions

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -316,6 +316,45 @@ describe('Client', function () {
         done();
       }, 1000);
     });
+
+    it('should create devices using default port (9999) when devicesUseDiscoveryPort is false', function (done) {
+      const devices = [];
+      client
+        .startDiscovery({
+          discoveryInterval: 250,
+          devicesUseDiscoveryPort: false,
+        })
+        .on('device-new', (device) => {
+          devices.push(device);
+        });
+
+      setTimeout(() => {
+        client.stopDiscovery();
+        expect(devices.length).to.be.greaterThan(0);
+        devices.forEach((d) => expect(d.port).to.eql(9999));
+        done();
+      }, 1000);
+    });
+
+    it('should create devices using response port when devicesUseDiscoveryPort is true', function (done) {
+      // This test assumes at least one test device is not responding to discovery 9999
+      const devices = [];
+      client
+        .startDiscovery({
+          discoveryInterval: 250,
+          devicesUseDiscoveryPort: true,
+        })
+        .on('device-new', (device) => {
+          devices.push(device);
+        });
+
+      setTimeout(() => {
+        client.stopDiscovery();
+        expect(devices.length).to.be.greaterThan(0);
+        expect(devices.findIndex((d) => d.port !== 9999)).to.not.eql(-1);
+        done();
+      }, 1000);
+    });
   });
 
   config.testSendOptionsSets.forEach((sendOptions) => {


### PR DESCRIPTION
TP-Link devices until now have responded to the discovery ping
using port 9999. Newer devices and firmware are now responding
back on a random port. The previous default would create device
connections defauling to the port the devices responded from,
which worked when they always used 9999. The new default
behavior will always create devices using the default port of
9999. This option can be set to `true` to use the previous behavior.

Related plasticrake/homebridge-tplink-smarthome#244
Related plasticrake/homebridge-tplink-smarthome#250