### PR TITLE
feat: catch more invalid discovery messages

### DIFF
--- a/test/setup-test.js
+++ b/test/setup-test.js
@@ -1,3 +1,5 @@
+const sinon = require('sinon');
+
 const {
   config,
   expect,
@@ -111,4 +113,9 @@ describe('Test Environment Setup', function () {
       });
     });
   });
+});
+
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
 });


### PR DESCRIPTION
Client#startDiscovery has been changed to emit Client#discovery-invalid
Instead of throwing an error in more cases than before when
processing incoming messages