### PR TITLE
chore!: drop support for node < v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest]
-        include:
-          - node-version: 14.x
-            os: ubuntu-latest
-            npm-version: '7'
 
     runs-on: ${{ matrix.os }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "commander": "^10.0.1",
+        "commander": "^11.1.0",
         "lodash.castarray": "^4.4.0",
         "lodash.clone": "^4.5.0",
         "lodash.defaultto": "^4.14.0",
@@ -35,7 +35,7 @@
         "@types/lodash.groupby": "^4.6.8",
         "@types/lodash.isequal": "^4.5.7",
         "@types/mocha": "^10.0.3",
-        "@types/node": "^18.18.8",
+        "@types/node": "^20.8.10",
         "@types/promise-queue": "^2.2.2",
         "@types/sinon-chai": "^3.2.11",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
@@ -59,7 +59,7 @@
         "nyc": "^15.1.0",
         "prettier": "3.0.3",
         "rimraf": "^5.0.5",
-        "sinon": "^15.2.0",
+        "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "source-map-support": "^0.5.21",
         "standard-version": "^9.5.0",
@@ -71,7 +71,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -1657,9 +1657,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
-      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2611,11 +2611,11 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/comment-json": {
@@ -3330,15 +3330,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cspell/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/cspell/node_modules/file-entry-cache": {
@@ -6709,9 +6700,9 @@
       "dev": true
     },
     "node_modules/nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
@@ -6719,6 +6710,24 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/node-fetch": {
@@ -8157,17 +8166,16 @@
       "dev": true
     },
     "node_modules/sinon": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
-      "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
-      "deprecated": "16.1.1",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.1.0",
-        "nise": "^5.1.4",
+        "nise": "^5.1.5",
         "supports-color": "^7.2.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:only": "cross-env NODE_ENV=test && nyc mocha --color"
   },
   "dependencies": {
-    "commander": "^10.0.1",
+    "commander": "^11.1.0",
     "lodash.castarray": "^4.4.0",
     "lodash.clone": "^4.5.0",
     "lodash.defaultto": "^4.14.0",
@@ -68,7 +68,7 @@
     "@types/lodash.groupby": "^4.6.8",
     "@types/lodash.isequal": "^4.5.7",
     "@types/mocha": "^10.0.3",
-    "@types/node": "^18.18.8",
+    "@types/node": "^20.8.10",
     "@types/promise-queue": "^2.2.2",
     "@types/sinon-chai": "^3.2.11",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
@@ -92,7 +92,7 @@
     "nyc": "^15.1.0",
     "prettier": "3.0.3",
     "rimraf": "^5.0.5",
-    "sinon": "^15.2.0",
+    "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.21",
     "standard-version": "^9.5.0",
@@ -104,7 +104,7 @@
     "typescript": "4.9.5"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "standard-version": {
     "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: Requires minimum node version v16