### PR TITLE
feat(Device)!: remove startPolling, stopPolling, that were previously deprecated

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -17,7 +17,14 @@ const logEvent = function logEvent(eventName, device, state) {
 // Use those if you want only events for those types and not all devices.
 client.on('device-new', (device) => {
   logEvent('device-new', device);
-  device.startPolling(5000);
+
+  // Poll device every 5 seconds
+  setTimeout(function pollDevice() {
+    device.getInfo().then((data) => {
+      console.log(data);
+      setTimeout(pollDevice, 5000);
+    });
+  }, 5000);
 
   // Device (Common) Events
   device.on('emeter-realtime-update', (emeterRealtime) => {

--- a/examples/events.ts
+++ b/examples/events.ts
@@ -20,7 +20,14 @@ const logEvent = function logEvent(
 // Use those if you want only events for those types and not all devices.
 client.on('device-new', (device) => {
   logEvent('device-new', device);
-  device.startPolling(5000);
+
+  // Poll device every 5 seconds
+  setTimeout(function pollDevice() {
+    device.getInfo().then((data: unknown) => {
+      console.log(data);
+      setTimeout(pollDevice, 5000);
+    });
+  }, 5000);
 
   // Device (Common) Events
   device.on('emeter-realtime-update', (emeterRealtime: RealtimeNormalized) => {

--- a/examples/multi-plug.js
+++ b/examples/multi-plug.js
@@ -41,7 +41,13 @@ const monitorEvents = function monitorEvents(device) {
     logEvent('in-use-update', device, inUse);
   });
 
-  device.startPolling(5000);
+  // Poll device every 5 seconds
+  setTimeout(function pollDevice() {
+    device.getInfo().then((data) => {
+      console.log(data);
+      setTimeout(pollDevice, 5000);
+    });
+  }, 5000);
 };
 
 (async () => {

--- a/examples/multi-plug.ts
+++ b/examples/multi-plug.ts
@@ -44,7 +44,13 @@ const monitorEvents = function monitorEvents(device: Device) {
     logEvent('in-use-update', device, inUse);
   });
 
-  device.startPolling(5000);
+  // Poll device every 5 seconds
+  setTimeout(function pollDevice() {
+    device.getInfo().then((data) => {
+      console.log(data);
+      setTimeout(pollDevice, 5000);
+    });
+  }, 5000);
 };
 
 (async () => {

--- a/src/bulb/index.ts
+++ b/src/bulb/index.ts
@@ -83,10 +83,6 @@ export interface BulbConstructorOptions extends DeviceConstructorOptions {
 interface BulbEvents {
   'emeter-realtime-update': (value: RealtimeNormalized) => void;
   /**
-   * @deprecated This will be removed in a future release.
-   */
-  'polling-error': (error: Error) => void;
-  /**
    * Bulb was turned on (`lightstate.on_off`).
    * @event Bulb#lightstate-on
    * @property {LightState} value lightstate

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -107,13 +107,8 @@ export interface DeviceEventEmitter {
     event: 'emeter-realtime-update',
     listener: (value: Realtime) => void,
   ): this;
-  /**
-   * @deprecated This will be removed in a future release.
-   */
-  on(event: 'polling-error', listener: (error: Error) => void): this;
 
   emit(event: 'emeter-realtime-update', value: RealtimeNormalized): boolean;
-  emit(event: 'polling-error', error: Error): boolean;
 }
 
 /**
@@ -142,8 +137,6 @@ export default abstract class Device
   private readonly udpConnection: UdpConnection;
 
   private readonly tcpConnection: TcpConnection;
-
-  private pollingTimer: NodeJS.Timeout | null = null;
 
   protected _sysInfo: Sysinfo;
 
@@ -470,46 +463,6 @@ export default abstract class Device
     }
 
     return childId;
-  }
-
-  /**
-   * Polls the device every `interval`.
-   *
-   * Returns `this` (for chaining) that emits events based on state changes.
-   * Refer to specific device sections for event details.
-   * @fires  Device#polling-error
-   * @param   interval - (ms)
-   *
-   * @deprecated This will be removed in a future release.
-   */
-  startPolling(interval: number): this {
-    const fn = async (): Promise<void> => {
-      try {
-        await this.getInfo();
-      } catch (err) {
-        this.log.debug(
-          '[%s] device.startPolling(): getInfo(): error:',
-          this.alias,
-          err,
-        );
-
-        this.emit('polling-error', err);
-      }
-    };
-    this.pollingTimer = setInterval(fn, interval);
-    fn();
-    return this;
-  }
-
-  /**
-   * Stops device polling.
-   *
-   * @deprecated This will be removed in a future release.
-   */
-  stopPolling(): void {
-    if (this.pollingTimer === null) return;
-    clearInterval(this.pollingTimer);
-    this.pollingTimer = null;
   }
 
   /**

--- a/src/plug/index.ts
+++ b/src/plug/index.ts
@@ -79,10 +79,6 @@ export interface PlugEventEmitter {
     listener: (value: RealtimeNormalized) => void,
   ): this;
   /**
-   * @deprecated This will be removed in a future release.
-   */
-  on(event: 'polling-error', listener: (error: Error) => void): this;
-  /**
    * Plug's relay was turned on.
    */
   on(event: 'power-on', listener: () => void): this;
@@ -111,7 +107,6 @@ export interface PlugEventEmitter {
   on(event: 'brightness-update', listener: (value: boolean) => void): this;
 
   emit(event: 'emeter-realtime-update', value: RealtimeNormalized): boolean;
-  emit(event: 'polling-error', error: Error): boolean;
 
   emit(event: 'power-on'): boolean;
   emit(event: 'power-off'): boolean;

--- a/test/device/index.js
+++ b/test/device/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 // spell-checker:ignore MYTESTMAC MYTESTMICMAC MYTESTETHERNETMAC
 
-const sinon = require('sinon');
 const {
   config,
   createUnresponsiveDevice,
@@ -476,112 +475,6 @@ describe('Device', function () {
                 'err_code',
                 0,
               );
-            });
-          });
-
-          describe('#startPolling()', function () {
-            let badDevice;
-            afterEach(function () {
-              device.stopPolling();
-              if (badDevice) badDevice.stopPolling();
-            });
-
-            it('should poll device', async function () {
-              const spy = sinon.spy();
-              await new Promise((resolve) => {
-                device.once('power-update', () => {
-                  spy();
-                  resolve();
-                });
-                device.once('in-use-update', () => {
-                  spy();
-                  resolve();
-                });
-                device.once('lightstate-update', () => {
-                  spy();
-                  resolve();
-                });
-                device.once('emeter-realtime-update', () => {
-                  spy();
-                  resolve();
-                });
-                device.startPolling(50);
-              });
-              expect(spy).to.be.called;
-            });
-
-            it('should fail to poll unreachable device', async function () {
-              this.timeout(500);
-              badDevice = await testDevice.getDevice(
-                {
-                  host: testDevices.unreachable.deviceOptions.host,
-                  sysInfo: device.sysInfo,
-                },
-                testSendOptions,
-              );
-
-              const spy = sinon.spy();
-
-              await new Promise((resolve) => {
-                badDevice.once('power-update', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.once('in-use-update', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.once('lightstate-update', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.once('emeter-realtime-update', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.startPolling(600);
-                setTimeout(resolve, 400);
-              });
-
-              expect(spy).to.not.be.called;
-            });
-
-            it('should throw error for unreachable device', async function () {
-              badDevice = await testDevice.getDevice(
-                undefined,
-                testSendOptions,
-              );
-              badDevice.host = testDevices.unreachable.deviceOptions.host;
-
-              const spy = sinon.spy();
-              await new Promise((resolve) => {
-                badDevice.once('polling-error', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.startPolling(200);
-              });
-
-              expect(spy).to.be.called;
-            });
-
-            it('should throw error for unreachable device', async function () {
-              badDevice = await testDevice.getDevice(
-                undefined,
-                testSendOptions,
-              );
-              badDevice.host = testDevices.unreachable.deviceOptions.host;
-
-              const spy = sinon.spy();
-              await new Promise((resolve) => {
-                badDevice.once('polling-error', () => {
-                  spy();
-                  resolve();
-                });
-                badDevice.startPolling(200);
-              });
-
-              expect(spy).to.be.called;
             });
           });
 


### PR DESCRIPTION
BREAKING CHANGE: `Device#startPolling`, `Device#stopPolling`, and Device/Bulb/Plug event `polling-error` have been removed.